### PR TITLE
v1.0.3: Fixed a NullReferenceException in ArchiveReader.CanExtractEntries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SevenZipSharp Changelog
 
+## [1.0.3] - 2025-01-07
+
+### Fixed
+
+- Fixed a NullReferenceException caused by calling `ArchiveReader.CanExtractEntries`.
+
 ## [1.0.2] - 2024-12-10
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<ProductName>SevenZip</ProductName>
 		<Copyright>exocad GmbH</Copyright>
 		<Authors>exocad GmbH</Authors>

--- a/src/SevenZip/ExtractContext.cs
+++ b/src/SevenZip/ExtractContext.cs
@@ -67,7 +67,7 @@ internal sealed partial class ExtractContext : MarshalByRefObject, IArchiveExtra
 
     private ArchiveEntry? GetArchiveEntry(uint index)
     {
-        if (index >= _reader.Count)
+        if (_reader == null || index >= _reader.Count)
         {
             return null;
         }
@@ -84,7 +84,7 @@ internal sealed partial class ExtractContext : MarshalByRefObject, IArchiveExtra
         }
         catch (Exception ex)
         {
-            _delegate.OnGetStreamFailed(index, entry, ex);
+            _delegate?.OnGetStreamFailed(index, entry, ex);
             result = OperationResult.Unavailable;
             return null;
         }
@@ -184,7 +184,7 @@ internal sealed partial class ExtractContext : MarshalByRefObject, IArchiveExtra
         {
             if (context != null && _index != null)
             {
-                context._delegate.OnExtractOperation((int)_index.Value, context.GetArchiveEntry(_index.Value), _operation, result);
+                context._delegate?.OnExtractOperation((int)_index.Value, context.GetArchiveEntry(_index.Value), _operation, result);
             }
 
             _operation = ExtractOperation.Skip;

--- a/test/SevenZipTests/ArchiveReaderTests.cs
+++ b/test/SevenZipTests/ArchiveReaderTests.cs
@@ -51,5 +51,18 @@ public class ArchiveReaderTests
         Directory.Delete("result-zip-7zs-simple", recursive: true);
  
         Assert.Equal(expectedEntryCount, counter.Result);
-   }
+    }
+
+    [Theory]
+    [InlineData("test-data/archive.zip")]
+    public void CanExtractEntries(string path)
+    {
+        // C:\Users\mkeuck\AppData\Local\Temp\LM\dl\2025-01-07_09-16-15_5540\ZIRKONZAHN All exocad libraries\ZIRKONZAHN All exocad libraries.zip
+
+        using var reader = new ArchiveReader(path);
+
+        var result = reader.CanExtractEntries();
+
+        Assert.True(result);
+    }
 }


### PR DESCRIPTION
This PR fixes a NullReferenceException in ArchiveReader.CanExtractEntries.