### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # SevenZipSharp Changelog
 
-## [2.1.1] - 2025-
+## [2.1.1] - 2025-02-27
 
 - Encrypted archives are now also supported on Linux. The PasswordProvider interfaces now pass a
   native pointer instead of a marshalled string which allows allocating the string the way the
   used implementation needs it, based on the current OS.
 - An exception is now thrown when applying the `CompressProperties` fails.
+- An empty string can now also be specified as password to use encryption.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # SevenZipSharp Changelog
 
+## [2.1.1] - 2025-
+
+- Encrypted archives are now also supported on Linux. The PasswordProvider interfaces now pass a
+  native pointer instead of a marshalled string which allows allocating the string the way the
+  used implementation needs it, based on the current OS.
+- An exception is now thrown when applying the `CompressProperties` fails.
+
+### Changed
+
 ## [2.1.0] - 2025-02-18
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <ProductName>SevenZip</ProductName>
     <Copyright>exocad GmbH</Copyright>
     <Authors>exocad GmbH</Authors>

--- a/src/SevenZip/CompressContext.cs
+++ b/src/SevenZip/CompressContext.cs
@@ -184,22 +184,22 @@ internal sealed partial class CompressContext : MarshalByRefObject, ICompressCon
     #endregion
 
     #region IPasswordProvider
-    int IPasswordProvider.CryptoGetPassword(out string password)
+    int IPasswordProvider.CryptoGetPassword(out nint password)
     {
         EnsureNotDisposed();
 
-        password = _writer.Config.Password;
+        password = StringMarshal.ManagedStringToBinaryString(_writer?.Config?.Password);
         return 0;
     }
     #endregion
 
     #region IPasswordProvider2
-    int IPasswordProvider2.CryptoGetTextPassword2(ref int passwordIsDefined, out string password)
+    int IPasswordProvider2.CryptoGetTextPassword2(ref int passwordIsDefined, out nint password)
     {
         EnsureNotDisposed();
 
-        passwordIsDefined = string.IsNullOrEmpty(_writer.Config.Password) ? 0 : 1;
-        password = _writer.Config.Password;
+        password = StringMarshal.ManagedStringToBinaryString(_writer?.Config?.Password);
+        passwordIsDefined = password != IntPtr.Zero ? 1 : 0;
         return 0;
     }
     #endregion

--- a/src/SevenZip/CompressProperties.cs
+++ b/src/SevenZip/CompressProperties.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using SevenZip.Detail;
 using SevenZip.Interop;
 
@@ -125,6 +126,8 @@ public sealed class CompressProperties
             }
 
             var result = setter.SetProperties(names.Pointer, values.Pointer, count);
+
+            Marshal.ThrowExceptionForHR(result);
         }
         finally
         {

--- a/src/SevenZip/Detail/StringMarshal.cs
+++ b/src/SevenZip/Detail/StringMarshal.cs
@@ -90,7 +90,7 @@ internal static class StringMarshal
     /// </returns>
     public static unsafe IntPtr ManagedStringToBinaryString(string value)
     {
-        if (string.IsNullOrEmpty(value))
+        if (value == null)
         {
             return IntPtr.Zero;
         }

--- a/src/SevenZip/ExtractContext.cs
+++ b/src/SevenZip/ExtractContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using SevenZip.Detail;
 using SevenZip.Interop;
 
 namespace SevenZip;
@@ -173,11 +174,11 @@ internal sealed partial class ExtractContext : MarshalByRefObject, IExtractConte
     #endregion
 
     #region IPasswordProvider
-    int IPasswordProvider.CryptoGetPassword(out string password)
+    int IPasswordProvider.CryptoGetPassword(out nint password)
     {
         EnsureNotDisposed();
 
-        password = _reader?.Config?.Password;
+        password = StringMarshal.ManagedStringToBinaryString(_reader?.Config?.Password);
         return 0;
     }
     #endregion

--- a/src/SevenZip/Interop/IPasswordProvider.cs
+++ b/src/SevenZip/Interop/IPasswordProvider.cs
@@ -23,11 +23,12 @@ interface IPasswordProvider
     /// Queries the password for the current archive.
     /// </summary>
     /// <param name="password">
-    /// If a password is set, it must be stored in this <c>out</c> parameter.
+    /// If a password is set, a new buffer containing the password must be assigned to this parameter.
+    /// The caller is responsible for freeing the buffer again.
     /// </param>
     /// <returns>
     /// A value of zero (0) on success, an error code otherwise.
     /// </returns>
     [PreserveSig]
-    int CryptoGetPassword([MarshalAs(UnmanagedType.BStr)] out string password);
+    int CryptoGetPassword(out nint password);
 }

--- a/src/SevenZip/Interop/IPasswordProvider2.cs
+++ b/src/SevenZip/Interop/IPasswordProvider2.cs
@@ -26,11 +26,12 @@ interface IPasswordProvider2
     /// If a password exists, this value must be set to 1. Otherwise, it must be set to zero.
     /// </param>
     /// <param name="password">
-    /// If a password is set, it must be stored in this <c>out</c> parameter.
+    /// If a password is set, a new buffer containing the password must be assigned to this parameter.
+    /// The caller is responsible for freeing the buffer again.
     /// </param>
     /// <returns>
     /// A value of zero (0) on success, an error code otherwise.
     /// </returns>
     [PreserveSig]
-    int CryptoGetTextPassword2(ref int passwordIsDefined, [MarshalAs(UnmanagedType.BStr)] out string password);
+    int CryptoGetTextPassword2(ref int passwordIsDefined, out nint password);
 }


### PR DESCRIPTION
- Encrypted archives are now also supported on Linux. The PasswordProvider interfaces now pass a
  native pointer instead of a marshalled string which allows allocating the string the way the
  used implementation needs it, based on the current OS.
- An exception is now thrown when applying the `CompressProperties` fails.
- An empty string can now also be specified as password to use encryption.
